### PR TITLE
Add missing ros dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,5 +17,6 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>azure-iothub-device-client-pip</exec_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -11,9 +11,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>rospy</depend>
   <depend>std_msgs</depend>
   
+  <exec_depend>rospy</exec_depend>
   <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>azure-iothub-device-client-pip</exec_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -10,13 +10,10 @@
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
-  <build_depend>rospy</build_depend>
-  <build_depend>std_msgs</build_depend>
 
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <depend>rospy</depend>
+  <depend>std_msgs</depend>
+  
   <exec_depend>rosbridge_library</exec_depend>
   <exec_depend>azure-iothub-device-client-pip</exec_depend>
 </package>


### PR DESCRIPTION
Adding rosbridge_library dependency, since code complained of missing dependency at runtime. Also removed duplicate rospy exec_depend, and moved rospy and std_msgs to generic depend tag, since they are used for both build and exec.