### PR TITLE
Fix missing relays append

### DIFF
--- a/ros_azure_iothub
+++ b/ros_azure_iothub
@@ -239,6 +239,7 @@ class IoTHubRelayNode(object):
         topic_matched_entity = self.get_relay_by_topic(topic)
         if topic_matched_entity is None:
             topic_matched_entity = RelayEntity(self, topic, str(msg_type), relay_mode)
+            self._relays.append(topic_matched_entity)
             rospy.logdebug("Generated relay entity for topic '%s' (%s) - Relay mode %s" % (topic, msg_type, relay_mode))
         elif topic_matched_entity.relay_mode != RelayEntity.RELAY_MODE_BIDIRECTIONAL and topic_matched_entity.relay_mode != relay_mode:
             topic_matched_entity.relay_mode = relay_mode

--- a/ros_azure_iothub
+++ b/ros_azure_iothub
@@ -204,7 +204,7 @@ class IoTHubRelayNode(object):
                         rospy.logerr("Relay mode for topic '%s' specified as '%s', which is not a supported value." % (topic, value['relay_mode']))
                         continue
                 self.register_relay(topic, msg_type, relay_mode)
-        self.save_relays()
+            self.save_relays()
 
     def _iot_hub_incoming_message_callback(self, msg, counter):
         try:


### PR DESCRIPTION
Adding append for _relays array. The save_relays function relies on the _relays array to have all of the up to date relays that have been registered.

Currently, there is nothing updating the _relays array, so an empty array overwrites the existing configuration file.