### PR TITLE
X509cert support

### DIFF
--- a/ros_azure_iothub
+++ b/ros_azure_iothub
@@ -280,13 +280,14 @@ class IoTHubRelayNode(object):
         if self._client.protocol == IoTHubTransportProvider.MQTT:
             self._client.set_option("logtrace", 0)
 
-        if rospy.has_param("~x509cert") and rospy.has_param("~x509privatekey"):
-            x509cert = rospy.get_param("~x509cert")
-            x509privatekey = rospy.get_param("~x509privatekey")
-            x509cert = self.read_cert_file(x509cert)
-            x509privatekey = self.read_cert_file(x509privatekey)
-            self._client.set_option("x509certificate", x509cert)
-            self._client.set_option("x509privatekey", x509privatekey)
+        if "x509=true" in connection_string:
+            if rospy.has_param("~x509cert") and rospy.has_param("~x509privatekey"):
+                x509cert = x509cert = self.read_cert_file(rospy.get_param("~x509cert"))
+                x509privatekey = self.read_cert_file(rospy.get_param("~x509privatekey"))
+                self._client.set_option("x509certificate", x509cert)
+                self._client.set_option("x509privatekey", x509privatekey)
+            else: 
+                rospy.logerr("Certificate info is missing from rosparam...")
 
         if self._client.protocol == IoTHubTransportProvider.MQTT or self._client.protocol == IoTHubTransportProvider.MQTT_WS:
             self._client.set_device_twin_callback(self._iot_hub_device_twin_callback, TWIN_CONTEXT)

--- a/ros_azure_iothub
+++ b/ros_azure_iothub
@@ -280,17 +280,17 @@ class IoTHubRelayNode(object):
         if self._client.protocol == IoTHubTransportProvider.MQTT:
             self._client.set_option("logtrace", 0)
 
-        if self._client.protocol == IoTHubTransportProvider.MQTT or self._client.protocol == IoTHubTransportProvider.MQTT_WS:
-            self._client.set_device_twin_callback(self._iot_hub_device_twin_callback, TWIN_CONTEXT)
-            self._client.set_device_method_callback(self._iot_hub_device_method_callback, METHOD_CONTEXT)
-
-	if rospy.has_param("~x509cert") and rospy.has_param("~x509privatekey"):
+        if rospy.has_param("~x509cert") and rospy.has_param("~x509privatekey"):
             x509cert = rospy.get_param("~x509cert")
             x509privatekey = rospy.get_param("~x509privatekey")
             x509cert = self.read_cert_file(x509cert)
             x509privatekey = self.read_cert_file(x509privatekey)
             self._client.set_option("x509certificate", x509cert)
             self._client.set_option("x509privatekey", x509privatekey)
+
+        if self._client.protocol == IoTHubTransportProvider.MQTT or self._client.protocol == IoTHubTransportProvider.MQTT_WS:
+            self._client.set_device_twin_callback(self._iot_hub_device_twin_callback, TWIN_CONTEXT)
+            self._client.set_device_method_callback(self._iot_hub_device_method_callback, METHOD_CONTEXT)
 
         self._client.set_message_callback(self._iot_hub_incoming_message_callback, RECEIVE_CONTEXT)
 

--- a/ros_azure_iothub
+++ b/ros_azure_iothub
@@ -284,6 +284,14 @@ class IoTHubRelayNode(object):
             self._client.set_device_twin_callback(self._iot_hub_device_twin_callback, TWIN_CONTEXT)
             self._client.set_device_method_callback(self._iot_hub_device_method_callback, METHOD_CONTEXT)
 
+	if rospy.has_param("~x509cert") and rospy.has_param("~x509privatekey"):
+            x509cert = rospy.get_param("~x509cert")
+            x509privatekey = rospy.get_param("~x509privatekey")
+            x509cert = self.read_cert_file(x509cert)
+            x509privatekey = self.read_cert_file(x509privatekey)
+            self._client.set_option("x509certificate", x509cert)
+            self._client.set_option("x509privatekey", x509privatekey)
+
         self._client.set_message_callback(self._iot_hub_incoming_message_callback, RECEIVE_CONTEXT)
 
         rospy.loginfo("Loading relay bridges from rosparam...")
@@ -296,6 +304,11 @@ class IoTHubRelayNode(object):
         msg_props = msg.properties()
         msg_props.add('topic', str(topic))
         self._client.send_event_async(msg, _iot_hub_confirmation_callback, self._counter)
+
+    def read_cert_file(self, path):
+        with open(path, 'r') as file:
+            contents = file.read().strip()
+        return contents
 
 def run_iot_hub_relay(node_name='ros_azure_iothub'):
     rospy.init_node(node_name)


### PR DESCRIPTION
Since provisioning service uses x509 certs for auth in many cases, this allows for using certs instead of keys.