### PR TITLE
[noetic] Report the topic messages as key/value JSON pairs for the relay

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - melodic-devel
+      - noetic-devel
   schedule:
     # Run it regularly to detect flaky build breaks.
     - cron:  '0 0 */3 * *'

--- a/roscpp_azure_iothub/README.md
+++ b/roscpp_azure_iothub/README.md
@@ -108,14 +108,14 @@ You should also see the `reported` properties section updated in your device twi
         },
         "reported": {
             "ros_messages": {
-                "/initialpose": [
-                    "/initialpose/header/seq = 39.000000",
-                    "/initialpose/header/stamp = 1600466498.040267",
-                    "/initialpose/pose/pose/position/x = 1.000000",
-                    "/initialpose/pose/pose/orientation/x = 0.000000",
-                    "/initialpose/pose/covariance.0 = 0.250000",
-                    "/initialpose/header/frame_id = map"
-                ]
+                "/initialpose": {
+                    "/initialpose/header/seq": "39.000000",
+                    "/initialpose/header/stamp": "1600466498.040267",
+                    "/initialpose/pose/pose/position/x": "1.000000",
+                    "/initialpose/pose/pose/orientation/x": "0.000000",
+                    "/initialpose/pose/covariance.0": "0.250000",
+                    "/initialpose/header/frame_id": "map"
+                }
             }
     }
 }

--- a/roscpp_azure_iothub/README.md
+++ b/roscpp_azure_iothub/README.md
@@ -68,10 +68,10 @@ catkin_make install
 source /install/setup.bash
 ```
 
-# Deployment (IoT Hub for telemetry reporting)
-Device twins are JSON documents that store device state information including metadata, configurations, and conditions. Azure IoT Hub maintains a device twin for each device that you connect to IoT Hub. And we are using `desired` properties as a channel to ask our ROS node what ROS topics to report.
+# Deployment (IoT Hub for telemetry reporting or reported properties channel)
+Device twins are JSON documents that store device state information including metadata, configurations, and conditions. Azure IoT Hub maintains a device twin for each device that you connect to IoT Hub. And we are using `desired` properties as a channel to ask our ROS node what ROS topics to report. The messages recieved from these ROS topics can either be reported through the telemetry channel or through the `reported` property channel. 
 
-Here is a JSON example to report `/rosout`:
+Here is a JSON example to report `/rosout` via telemetry and `/initialpose` via reported properties:
 
 ``` json
 {
@@ -79,7 +79,14 @@ Here is a JSON example to report `/rosout`:
     "properties": {
         "desired": {
             "ros_relays": {
-                "1": "/rosout"
+                "1": {
+                    "topic": "/rosout",
+                    "relay_method": "telemetry"
+                },
+                "2": {
+                    "topic": "/initialpose",
+                    "relay_method": "reported"
+                }
             }
         }
     }
@@ -91,7 +98,28 @@ And add the `ros_relays` block to the device twin which you are about to connect
 ``` bash
 az iot hub monitor-events --hub-name <YourIoTHubName> --output table
 ```
-
+You should also see the `reported` properties section updated in your device twin each time `/initialpose` is published to:
+(Note: The message recieved from `/initialpose` below is consolidated for brevity)
+``` json
+{
+    "deviceId": "devA",
+    "properties": {
+        "desired": {
+        },
+        "reported": {
+            "ros_messages": {
+                "/initialpose": [
+                    "/initialpose/header/seq = 39.000000",
+                    "/initialpose/header/stamp = 1600466498.040267",
+                    "/initialpose/pose/pose/position/x = 1.000000",
+                    "/initialpose/pose/pose/orientation/x = 0.000000",
+                    "/initialpose/pose/covariance.0 = 0.250000",
+                    "/initialpose/header/frame_id = map"
+                ]
+            }
+    }
+}
+```
 # Deployment (IoT Hub for dynamic configuration)
 [Dynamic Reconfiguration](http://wiki.ros.org/dynamic_reconfigure) provides a way to change the node parameters during runtime without restarting the node.
 Similar as the telemetry reporting, we are using the device twin `desired` properties as a channel to ask our ROS node what dynamic parameters to reconfigure.

--- a/roscpp_azure_iothub/README.md
+++ b/roscpp_azure_iothub/README.md
@@ -69,7 +69,7 @@ source /install/setup.bash
 ```
 
 # Deployment (IoT Hub for telemetry reporting or reported properties channel)
-Device twins are JSON documents that store device state information including metadata, configurations, and conditions. Azure IoT Hub maintains a device twin for each device that you connect to IoT Hub. And we are using `desired` properties as a channel to ask our ROS node what ROS topics to report. The messages recieved from these ROS topics can either be reported through the telemetry channel or through the `reported` property channel. 
+Device twins are JSON documents that store device state information including metadata, configurations, and conditions. Azure IoT Hub maintains a device twin for each device that you connect to IoT Hub. And we are using `desired` properties as a channel to ask our ROS node what ROS topics to report. The messages recieved from these ROS topics can either be reported through the telemetry channel or through the `reported` property channel. The telemetry channel is designed for high bandwidth data and the history of messages sent over this channel are stored. The reported property channel is designed for low bandwidth data and it advertises only the latest message for each topic that is subscribed to. 
 
 Here is a JSON example to report `/rosout` via telemetry and `/initialpose` via reported properties:
 

--- a/roscpp_azure_iothub/src/ros_azure_iothub_cpp_node.cpp
+++ b/roscpp_azure_iothub/src/ros_azure_iothub_cpp_node.cpp
@@ -227,7 +227,7 @@ static char* serializeToJson(std::string topic, std::string message)
     JSON_Object* root_object = json_value_get_object(root_value);
 
     std::string topic_header = "ros_messages." + topic;
-    std::string msg = "[" + message + "]";
+    std::string msg = "{" + message + "}";
     (void)json_object_dotset_value(root_object, topic_header.c_str(), json_parse_string(msg.c_str()));
 
     result = json_serialize_to_string_pretty(root_value);
@@ -248,18 +248,14 @@ void buildReportedString(std::string& topic_msg, std::string msg)
 {
     if(topic_msg.empty())
     {
-        topic_msg += "\"";
         topic_msg += msg;
-        topic_msg += "\"";
     }
     else 
     {
-        topic_msg += ",\"";
+        topic_msg += ", ";
         topic_msg += msg;
-        topic_msg += "\"";
     }
 }
-
 
 void topicCallback(const topic_tools::ShapeShifter::ConstPtr& msg,
                    const std::string &topic_name,
@@ -297,13 +293,13 @@ void topicCallback(const topic_tools::ShapeShifter::ConstPtr& msg,
         ROS_DEBUG("Sending message from %s to IoTHub via reported properties ", topic_name.c_str()); 
 
         std::string topic_msg = "";
-
+        (void) reportedProperties;
         for (auto it: renamed_values)
         {
             const std::string& key = it.first;
             const Variant& value   = it.second;
             char char_buffer [256] = {0};
-            snprintf(char_buffer, sizeof(char_buffer), "%s = %f", key.c_str(), value.convert<double>());
+            snprintf(char_buffer, sizeof(char_buffer), "\"%s\":\"%f\"", key.c_str(), value.convert<double>());
             buildReportedString(topic_msg, (std::string)char_buffer);
         }
         for (auto it: flat_container.name)
@@ -311,7 +307,7 @@ void topicCallback(const topic_tools::ShapeShifter::ConstPtr& msg,
             const std::string& key    = it.first.toStdString();
             const std::string& value  = it.second;
             char char_buffer [256] = {0};
-            snprintf(char_buffer, sizeof(char_buffer), "%s = %s", key.c_str(), value.c_str());
+            snprintf(char_buffer, sizeof(char_buffer), "\"%s\":\"%s\"", key.c_str(), value.c_str());
             buildReportedString(topic_msg, (std::string)char_buffer);
         }
 

--- a/roscpp_azure_iothub/src/ros_azure_iothub_cpp_node.cpp
+++ b/roscpp_azure_iothub/src/ros_azure_iothub_cpp_node.cpp
@@ -244,14 +244,13 @@ static void reportedStateCallback(int status_code, void* userContextCallback)
     printf("Device Twin reported properties update completed with result: %d\r\n", status_code);
 }
 
-void buildReportedString(std::string& topic_msg, std::string msg, bool& first)
+void buildReportedString(std::string& topic_msg, std::string msg)
 {
-    if(first)
+    if(topic_msg.empty())
     {
         topic_msg += "\"";
         topic_msg += msg;
         topic_msg += "\"";
-        first = false;
     }
     else 
     {
@@ -295,26 +294,25 @@ void topicCallback(const topic_tools::ShapeShifter::ConstPtr& msg,
     // Send info to IoTHub via reported properties 
     if (!(std::find(topicsToReport.begin(), topicsToReport.end(), topic_name.c_str()) == topicsToReport.end()))
     {
-        ROS_INFO("Sending message from %s to IoTHub via reported properties ", topic_name.c_str()); 
+        ROS_DEBUG("Sending message from %s to IoTHub via reported properties ", topic_name.c_str()); 
 
         std::string topic_msg = "";
-        bool first = true;
 
         for (auto it: renamed_values)
         {
             const std::string& key = it.first;
             const Variant& value   = it.second;
-            char _buffer [256] = {0};
-            snprintf(_buffer, sizeof(_buffer), "%s = %f", key.c_str(), value.convert<double>());
-            buildReportedString(topic_msg, (std::string)_buffer, first);
+            char char_buffer [256] = {0};
+            snprintf(char_buffer, sizeof(char_buffer), "%s = %f", key.c_str(), value.convert<double>());
+            buildReportedString(topic_msg, (std::string)char_buffer);
         }
         for (auto it: flat_container.name)
         {
             const std::string& key    = it.first.toStdString();
             const std::string& value  = it.second;
-            char _buffer [256] = {0};
-            snprintf(_buffer, sizeof(_buffer), "%s = %s", key.c_str(), value.c_str());
-            buildReportedString(topic_msg, (std::string)_buffer, first);
+            char char_buffer [256] = {0};
+            snprintf(char_buffer, sizeof(char_buffer), "%s = %s", key.c_str(), value.c_str());
+            buildReportedString(topic_msg, (std::string)char_buffer);
         }
 
         reportedProperties = serializeToJson(topic_name, topic_msg);
@@ -328,19 +326,19 @@ void topicCallback(const topic_tools::ShapeShifter::ConstPtr& msg,
         {
             const std::string& key = it.first;
             const Variant& value   = it.second;
-            char _buffer [256] = {0};
-            snprintf(_buffer, sizeof(_buffer), " %s = %f", key.c_str(), value.convert<double>());
-            ROS_INFO("%s",_buffer);
-            sendMsgToAzureIoTHub(_buffer, deviceHandle);
+            char char_buffer [256] = {0};
+            snprintf(char_buffer, sizeof(char_buffer), " %s = %f", key.c_str(), value.convert<double>());
+            ROS_INFO("%s",char_buffer);
+            sendMsgToAzureIoTHub(char_buffer, deviceHandle);
         }
         for (auto it: flat_container.name)
         {
             const std::string& key    = it.first.toStdString();
             const std::string& value  = it.second;
-            char _buffer [256] = {0};
-            snprintf(_buffer, sizeof(_buffer), " %s = %s", key.c_str(), value.c_str());
-            ROS_INFO("%s",_buffer);
-            sendMsgToAzureIoTHub(_buffer, deviceHandle);
+            char char_buffer [256] = {0};
+            snprintf(char_buffer, sizeof(char_buffer), " %s = %s", key.c_str(), value.c_str());
+            ROS_INFO("%s",char_buffer);
+            sendMsgToAzureIoTHub(char_buffer, deviceHandle);
         }
     }
 }


### PR DESCRIPTION
The ros_relay reported property output was changed slightly to have a key/value JSON pair format instead of just strings for topic messages. 