### PR TITLE
[noetic] Fixing a recycled pointer accidentally used in subscribeTopic

### DIFF
--- a/roscpp_azure_iothub/src/ros_azure_iothub_cpp_node.cpp
+++ b/roscpp_azure_iothub/src/ros_azure_iothub_cpp_node.cpp
@@ -353,7 +353,7 @@ static void subscribeTopic(const char* topicName, ROS_Azure_IoT_Hub* iotHub)
     std::string topicNameCopy(topicName);
     callback = [iotHub, topicNameCopy](const topic_tools::ShapeShifter::ConstPtr& msg) -> void
     {
-        topicCallback(msg, topicName, iotHub->parser, iotHub->deviceHandle, iotHub->topicsToReport, iotHub->reportedProperties);
+        topicCallback(msg, topicNameCopy.c_str(), iotHub->parser, iotHub->deviceHandle, iotHub->topicsToReport, iotHub->reportedProperties);
     };
     iotHub->subscribers.push_back( iotHub->nh.subscribe(topicName, 10, callback) );
 }

--- a/roscpp_azure_iothub/src/ros_azure_iothub_cpp_node.cpp
+++ b/roscpp_azure_iothub/src/ros_azure_iothub_cpp_node.cpp
@@ -350,7 +350,8 @@ void topicCallback(const topic_tools::ShapeShifter::ConstPtr& msg,
 static void subscribeTopic(const char* topicName, ROS_Azure_IoT_Hub* iotHub)
 {
     boost::function<void(const topic_tools::ShapeShifter::ConstPtr&) > callback;
-    callback = [iotHub, topicName](const topic_tools::ShapeShifter::ConstPtr& msg) -> void
+    std::string topicNameCopy(topicName);
+    callback = [iotHub, topicNameCopy](const topic_tools::ShapeShifter::ConstPtr& msg) -> void
     {
         topicCallback(msg, topicName, iotHub->parser, iotHub->deviceHandle, iotHub->topicsToReport, iotHub->reportedProperties);
     };


### PR DESCRIPTION
The `topicName` has shorter life cycle than the `callback`. Passing by pointer will cause the callback dereferencing a recycled pointer. This pull request is to make the lambda to capture the string copy instead. 