### PR TITLE
Fix package dependency

### DIFF
--- a/roscpp_azure_iothub/package.xml
+++ b/roscpp_azure_iothub/package.xml
@@ -19,6 +19,6 @@
   <depend>std_msgs</depend>
   <depend>topic_tools</depend>
   <depend>ros_type_introspection</depend>
-  <depend>libazure-iot-sdk-c</depend>
+  <depend>azure-iot-sdk-c</depend>
   <test_depend>rosunit</test_depend>
 </package>


### PR DESCRIPTION
Fix [#41 ](https://github.com/microsoft/ros_azure_iothub/issues/41).

Following [How to Build (Ubuntu Linux install)](https://github.com/microsoft/ros_azure_iothub#how-to-build-ubuntu-linux-install), the error occur like
```
$ rosdep install --from-paths src --ignore-src -r -y
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
roscpp_azure_iothub: Cannot locate rosdep definition for [libazure-iot-sdk-c]
Continuing to install resolvable dependencies...
#All required rosdeps installed successfully
```

As @Timple said
> This is because the dependency is listed as libazure-iot-sdk-c [source](https://github.com/microsoft/ros_azure_iothub/blob/610bba796378715efe25737b13c0598e01bef34b/roscpp_azure_iothub/package.xml#L22)
> While it is registered in rosdep as azure-iot-sdk-c [source](https://github.com/ros/rosdistro/blob/90af2f9e130027cbbf01f45ba382b800eefb0fbb/melodic/distribution.yaml#L816)


Now I tested only melodic-devel, but maybe the other branchs should be also fixed. 